### PR TITLE
Use xdelta3 package instead of binary when already installed

### DIFF
--- a/builder/build-nethersx2.sh
+++ b/builder/build-nethersx2.sh
@@ -47,7 +47,11 @@ patch() {
     # Patching the file
     echo -ne "\e[96mPatching to \e[0m\e[91mNetherSX2...\e[0m"
     for i in "$input_path"/*.apk; do
-        $p2f/lib/xdelta3 -d -f -s "$i" "$xdelta_patch" "$output_path/$(basename "$i" .apk)$patched_end.apk"
+        if command -v xdelta3 &> /dev/null; then
+            xdelta3 -d -f -s "$i" "$xdelta_patch" "$output_path/$(basename "$i" .apk)$patched_end.apk"
+        else
+            $p2f/lib/xdelta3 -d -f -s "$i" "$xdelta_patch" "$output_path/$(basename "$i" .apk)$patched_end.apk"
+        fi
     done
     echo -e "\e[92m[Done]\e[0m"
     read -p "Press Enter to exit..."


### PR DESCRIPTION
Use the installed xdelta3 package instead of built-in binary when it's already installed.
Why? the provided binaries are x64-x86, which doesn't work in arm64 devices (e.g. Termux).
This way, arm64 and i686 users can install xdelta3 by themselves.