### PR TITLE
Hardware renderer fix for Drakengard, recommendation for SWBF2

### DIFF
--- a/assets/GameIndex.yaml
+++ b/assets/GameIndex.yaml
@@ -16974,7 +16974,8 @@ SLES-52322:
     cpuFramebufferConversion: 1 # Fixes garbage rendering presentation.
     textureInsideRT: 1 # Fixes rendering
     disablePartialInvalidation: 1 # Corrects color from textureInsideRT, unique to 4248.
-    roundSprite: 1 # Fixes blue rectangle and line artifacts
+    halfPixelOffset: 2 # Fixes block shaped artifacts when upscaling
+    roundSprite: 1 # Fixes blue line artifacts when upscaling
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
@@ -50828,7 +50829,8 @@ SLUS-20732:
     cpuFramebufferConversion: 1 # Fixes garbage rendering presentation.
     textureInsideRT: 1 # Fixes rendering
     disablePartialInvalidation: 1 # Corrects color from textureInsideRT, unique to 4248.
-    roundSprite: 1 # Fixes blue rectangle and line artifacts
+    halfPixelOffset: 2 # Fixes block shaped artifacts when upscaling
+    roundSprite: 1 # Fixes blue line artifacts when upscaling
 SLUS-20733:
   name: "Castlevania - Lament of Innocence"
   region: "NTSC-U"

--- a/assets/GameIndex.yaml
+++ b/assets/GameIndex.yaml
@@ -16971,6 +16971,10 @@ SLES-52322:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    cpuFramebufferConversion: 1 # Fixes garbage rendering presentation.
+    textureInsideRT: 1 # Fixes rendering
+    disablePartialInvalidation: 1 # Corrects color from textureInsideRT, unique to 4248.
+    roundSprite: 1 # Fixes blue rectangle and line artifacts
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
@@ -20089,16 +20093,19 @@ SLES-53501:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
+    recommendedBlendingLevel: 3 # Corrects lightning when using Vulkan
 SLES-53502:
   name: "Star Wars - Battlefront II"
   region: "PAL-F"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
+    recommendedBlendingLevel: 3 # Corrects lightning when using Vulkan
 SLES-53503:
   name: "Star Wars - Battlefront II"
   region: "PAL-G"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
+    recommendedBlendingLevel: 3 # Corrects lightning when using Vulkan
 SLES-53504:
   name: "Agent Hugo"
   region: "PAL-M11"
@@ -37117,6 +37124,7 @@ SLPM-66190:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
+    recommendedBlendingLevel: 3 # Corrects lightning when using Vulkan
 SLPM-66191:
   name: "Tiger Woods PGA Tour 06"
   region: "NTSC-J"
@@ -50817,6 +50825,10 @@ SLUS-20732:
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
     mergeSprite: 1 # Fixes misaligned white lines.
     PCRTCOverscan: 1 # Fixes missing HUD.
+    cpuFramebufferConversion: 1 # Fixes garbage rendering presentation.
+    textureInsideRT: 1 # Fixes rendering
+    disablePartialInvalidation: 1 # Corrects color from textureInsideRT, unique to 4248.
+    roundSprite: 1 # Fixes blue rectangle and line artifacts
 SLUS-20733:
   name: "Castlevania - Lament of Innocence"
   region: "NTSC-U"
@@ -53608,6 +53620,7 @@ SLUS-21240:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes bloom misalignment.
+    recommendedBlendingLevel: 3 # Corrects lightning when using Vulkan
 SLUS-21241:
   name: "NHL '06"
   region: "NTSC-U"


### PR DESCRIPTION
- "Drakengard":

Default Software Rendering, followed by its Hardware Rendering
![Screenshot_20231204-154133](https://github.com/Trixarian/NetherSX2-patch/assets/38172391/3b96fc58-c12b-482d-a8fa-0aba63d1a1ce)
![Screenshot_20231204-154228](https://github.com/Trixarian/NetherSX2-patch/assets/38172391/56363c3f-ed3a-4c55-bf64-a1ecaba05901)

Hardware rendering with fixes applied.
![Screenshot_20231204-155103](https://github.com/Trixarian/NetherSX2-patch/assets/38172391/1444cd7e-279e-427b-a780-0b2cc011b221)

Comments in GameIndex.yaml explains a little more what does what. Possibly Software Rendering still is faster.

If "Drakengard 2" has similar issues with broken hardware rendering, it could be worth it to test these applied fixes.
  
  
- "Star Wars Battlefront II":

Vulkan has been the way to play this game on AetherSX2 as OpenGL rendering has broken graphics, however Vulkan has broken lightning.

Setting "Blending Accuracy" to at least "High" fixes it, assigned as "recommended" in GameDB.
![Screenshot_20231204-153806](https://github.com/Trixarian/NetherSX2-patch/assets/38172391/678138d2-2b2d-4691-b2d4-252f30e24d5c)
![Screenshot_20231204-153829](https://github.com/Trixarian/NetherSX2-patch/assets/38172391/c75e5868-c498-4fa6-ae74-ccbc7a200828)
