### PR TITLE
Make curl to follow redirects.

### DIFF
--- a/builder/build-nethersx2.sh
+++ b/builder/build-nethersx2.sh
@@ -62,7 +62,7 @@ patch() {
 
 nofile() {
     echo -ne "\e[96mDownloading \e[0m\e[94mAetherSX2...\e[0m"
-    curl -s -o "$input_path/15210-v1.5-4248.apk" "https://github.com/Trixarian/NetherSX2-patch/releases/download/0.0/15210-v1.5-4248.apk"
+    curl -sL -o "$input_path/15210-v1.5-4248.apk" "https://github.com/Trixarian/NetherSX2-patch/releases/download/0.0/15210-v1.5-4248.apk"
     echo -e "\e[92m[Done]\e[0m"
     patch
 }


### PR DESCRIPTION
On my machine, the build-nethersx2.sh failed to download the original APK. The reason was the `curl` command didn't follow redirections. Add `-L` to follow redirections.