### PR TITLE
Add Docker build container for local usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM --platform=linux/amd64 openjdk:25-bookworm
+ADD entrypoint.sh /
+
+RUN apt update && apt install -y unzip xdelta3 && mkdir -p /app && chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Credit: [TheKingFireS](https://github.com/TheKingFireS) + [BryanJacobs](https://
 
 And there you go, you should now have an updated and bug fixed copy of NetherSX2 for your phone!
 
+**Docker version:**  
+
+To use Docker to patch the APK, copy the Dockerfile, build the container and run it:
+
+```bash
+wget https://raw.githubusercontent.com/Trixarian/NetherSX2-patch/refs/heads/main/Dockerfile
+wget https://raw.githubusercontent.com/Trixarian/NetherSX2-patch/refs/heads/main/entrypoint.sh
+
+docker build --platform linux/amd64  -t nethersx2-patch .
+docker run -it --rm -platform linux/amd64 -v ${PWD}/output/:/output nethersx2-patch
+```
+
+Your updated and bug fixed copy of NetherSX2 APK should be in `${PWD}/output`!
+
 ## Using Builder on Windows + Linux
 1. Grab a copy of [NetherSX2-builder.zip](https://github.com/Trixarian/NetherSX2-patch/releases/download/1.8/NetherSX2-builder.zip) file from this repository
 2. Unzip the zip file by right clicking and selecting Extracting Here, and enter the now extracted builder folder

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd /app
+wget https://github.com/Trixarian/NetherSX2-patch/archive/refs/heads/main.zip
+unzip *zip
+
+cd /app/NetherSX2-patch-main
+chmod +x ./patch-apk.sh
+./patch-apk.sh
+
+cp *4248*.apk* /output/


### PR DESCRIPTION
This PR adds a Dockerfile + entrypoint script to build the latest APK.

This also works on MacOS.